### PR TITLE
chore: remove uppercase from package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "VEBERArnaud/cli-framework",
+    "name": "veberarnaud/cli-framework",
     "description": "CLI framework",
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
## Description

fix: invalid package name
